### PR TITLE
Bug Fix: cutscene A0S18 not working (based from Main)

### DIFF
--- a/Assets/Audio/Dialogue Configs/Narrator.asset.meta
+++ b/Assets/Audio/Dialogue Configs/Narrator.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0282d09d81d01944bb2e0d5f8f92d02c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/Dialogue Configs/Noelle's Father.asset.meta
+++ b/Assets/Audio/Dialogue Configs/Noelle's Father.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a49a34d35621b0a4ea70396dd7ade2b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/Dialogue Configs/Noelle's Grandfather.asset.meta
+++ b/Assets/Audio/Dialogue Configs/Noelle's Grandfather.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32c0af1bc2b63e541b8528b4ff8cacac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/Dialogue Configs/Noelle's Mother.asset.meta
+++ b/Assets/Audio/Dialogue Configs/Noelle's Mother.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 581c0c2d15c4b2e40b54b27be33e96ab
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GameAssets/Art/Cutscenes/DuskIsland/Cutscene 1/cutscene controller.controller
+++ b/Assets/GameAssets/Art/Cutscenes/DuskIsland/Cutscene 1/cutscene controller.controller
@@ -493,7 +493,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: AS018
+  m_Name: A0S18
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions: []


### PR DESCRIPTION
cause of bug: a spelling mistake in the id of the cutscene 

This reverts commit 6e2c0b2fa8f6573ff6dbc89c4704160744484b99.