### PR TITLE
refactor: remove asset from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,3 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
-*.asset

--- a/Assets/Audio/Configs/Music/Post-transformation.asset.meta
+++ b/Assets/Audio/Configs/Music/Post-transformation.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 21a586770469df840b6fb1fb2473947d
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 11400000
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Audio/Dialogue Configs/Noelle's Father.asset.meta
+++ b/Assets/Audio/Dialogue Configs/Noelle's Father.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a49a34d35621b0a4ea70396dd7ade2b0
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Audio/Dialogue Configs/Noelle's Grandfather.asset.meta
+++ b/Assets/Audio/Dialogue Configs/Noelle's Grandfather.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 32c0af1bc2b63e541b8528b4ff8cacac
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Audio/Dialogue Configs/Noelle's Mother.asset.meta
+++ b/Assets/Audio/Dialogue Configs/Noelle's Mother.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 581c0c2d15c4b2e40b54b27be33e96ab
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/NPC/NpcDataScriptableObjects/AmeliaData.asset.meta
+++ b/Assets/Scripts/NPC/NpcDataScriptableObjects/AmeliaData.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a37b9579015d9304a86f464b7f5b2ad2
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/NPC/NpcDataScriptableObjects/TestData.asset.meta
+++ b/Assets/Scripts/NPC/NpcDataScriptableObjects/TestData.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 15624c20aa57a924cbab8487562fd9ee
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Removes `.asset` from the gitignore because this meant that any scriptable objects we created were not being pushed. This removes a lot of the .asset.meta files from #25 because they were not able to be pushed due to the gitignore