### PR TITLE
put script back

### DIFF
--- a/Assets/Scripts/Player/Inventory/ItemHarvester.cs
+++ b/Assets/Scripts/Player/Inventory/ItemHarvester.cs
@@ -5,6 +5,7 @@ public class ItemHarvester : MonoBehaviour
 {
     [NonSerialized]
     public ItemHarvestSource source = null;
+    private ItemHarvestSource oldSource = null;
 
     void FixedUpdate()
     {
@@ -21,15 +22,19 @@ public class ItemHarvester : MonoBehaviour
     {
         if (other.gameObject.CompareTag("ItemResource"))
         {
+            if(source != null) oldSource = source; // If there already was a source, remember which one it was
             source = other.gameObject.GetComponent<ItemHarvestSource>();
         }
     }
 
     private void OnTriggerExit(Collider other)
     {
-        if (other.gameObject.CompareTag("ItemResource") && source != null)
+        if (other.gameObject.CompareTag("ItemResource"))
         {
-            source = null;
+            if (source == oldSource) // Exited the source with no new source entered
+                source = null;
+            else                     // Exited the source but there is a new source
+                oldSource = source;
         }
     }
 }


### PR DESCRIPTION
## Fixed issue of harvest source being set to null
![image](https://github.com/user-attachments/assets/62556eb0-d2ab-4960-9764-07aede647bb7)
- The old script made it so that each time the player exited a harvest source trigger, the source variable would be set to null.
- This was a bug because there could be item sources right next to each other and the player could simultaneously enter a new one and exit an old one, which would set the harvest source component to set it to null. Hence, making the player unable to harvest the items.
- Fixed by adding a variable to track the old source and record which source was being exited and entered.
   - _(look at this in the harvester script)_