### PR TITLE
fixing bug that player collides agianst AmeliaNPC

### DIFF
--- a/Assets/Prefabs/NoonIsland/NPC/AmeliaNPC.prefab
+++ b/Assets/Prefabs/NoonIsland/NPC/AmeliaNPC.prefab
@@ -108,6 +108,10 @@ PrefabInstance:
       propertyPath: inkJSON
       value: 
       objectReference: {fileID: 4900000, guid: 45715c65d01e4d7449751d42db72a62e, type: 3}
+    - target: {fileID: 2573145739525454253, guid: 937de99fd5fdaa748ab8beb026345b54, type: 3}
+      propertyPath: m_ExcludeLayers.m_Bits
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3849503128907647850, guid: 937de99fd5fdaa748ab8beb026345b54, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.08
@@ -156,6 +160,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6268503043563416342, guid: 937de99fd5fdaa748ab8beb026345b54, type: 3}
+      propertyPath: m_ExcludeLayers.m_Bits
+      value: 128
+      objectReference: {fileID: 0}
     - target: {fileID: 7555173281025391573, guid: 937de99fd5fdaa748ab8beb026345b54, type: 3}
       propertyPath: questID
       value: quest_id1
@@ -183,6 +191,10 @@ PrefabInstance:
     - target: {fileID: 7676932983616058637, guid: 937de99fd5fdaa748ab8beb026345b54, type: 3}
       propertyPath: maxDistance
       value: 3.65
+      objectReference: {fileID: 0}
+    - target: {fileID: 8035855133781098471, guid: 937de99fd5fdaa748ab8beb026345b54, type: 3}
+      propertyPath: m_IncludeLayers.m_Bits
+      value: 128
       objectReference: {fileID: 0}
     - target: {fileID: 8383165320316243045, guid: 937de99fd5fdaa748ab8beb026345b54, type: 3}
       propertyPath: m_Name

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 286741087519335697}
   - component: {fileID: 9187045717532970881}
   - component: {fileID: 3800245460030639579}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Player
   m_TagString: Player
   m_Icon: {fileID: 0}
@@ -101,7 +101,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 33e49fcc87d03a041bc81d0c9ffd409c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerSave: {fileID: 11400000, guid: 055a02550362f41f89f8b9829825b4b4, type: 2}
   inputProvider: {fileID: 11400000, guid: 56d05f6f40325fc459c9a2a4a6bd0ab0, type: 2}
   moveSpeed: 1.2
   spriteTransform: {fileID: 6391069182455531222}
@@ -130,7 +129,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4d674e172e0d9f449bf24012d3656619, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  questID: 0
+  quest: {fileID: 0}
 --- !u!114 &9187045717532970881
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -167,7 +166,7 @@ GameObject:
   - component: {fileID: 7498922723279976638}
   - component: {fileID: 5514603575849100926}
   - component: {fileID: 6391069182455531222}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Sprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}


### PR DESCRIPTION
bug fix for [NPCs can be pushed by player](https://github.com/unimelb-game-makers/TeamAqua/issues/26)

Changed layer of the Player prefab from default to Player, and set AmeliaNPC's boxCollider to include Player layer, but player layer excluded by sphereCollider.

The player passes through the Amelia now, but it can still interacts via dialogue system