### PR TITLE
fix(player): change move input to zero if cannot move

### DIFF
--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -14,11 +14,9 @@ public class PlayerController : MonoBehaviour, ISaveable
 
     [SerializeField]
     private float groundCheckDistance = 0.32f;
-    private float speed; //freezes movement or resume movement depending on condition check
 
     private Rigidbody rb;
     private Vector3 moveInput;
-    private Vector3 moveVelocity;
 
     private Vector3 spriteScale;
 
@@ -59,13 +57,10 @@ public class PlayerController : MonoBehaviour, ISaveable
     // Update is called once per frame
     void Update()
     {
-        moveInput = new Vector3(Input.GetAxisRaw("Horizontal"), 0f, Input.GetAxisRaw("Vertical"));
-        moveVelocity = moveInput * speed;
+        moveInput = inputProvider.can_move ? new Vector3(Input.GetAxisRaw("Horizontal"), 0f, Input.GetAxisRaw("Vertical")) : Vector3.zero;
         if (inputProvider.can_move)    //Checks whether to freeze movement. This will be reworked later
         {                                                   
-            speed = moveSpeed;
             /*Play Animations here*/
-            
             if(moveInput.x > 0){// Walk Right
                 anim.ChangeAnimationState("Walk");
                 spriteTransform.flipX(true);
@@ -91,7 +86,6 @@ public class PlayerController : MonoBehaviour, ISaveable
         }
         else
         {
-            speed = 0;
             anim.ChangeAnimationState("Idle");
             //AudioManager.Instance.Stop("BGM_SFX_WALKING");
         }


### PR DESCRIPTION
fixes #71

The bug is that the slope calculation takes move input even though the player cannot move. I've done the following:
- set move input to 0 when the player cannot move (this is cleanest imo)
- got rid of unused variables