### PR TITLE
fix(dialogue): end line coroutine when skipping to stop dialogue audio

### DIFF
--- a/Assets/Scripts/UI/DialoguePopup.cs
+++ b/Assets/Scripts/UI/DialoguePopup.cs
@@ -65,6 +65,7 @@ namespace Popups
         [Button]
         public void Skip()
         {
+            EndCoroutine();
             DialogueManager.Instance().SkipStory();
         }
 


### PR DESCRIPTION
fixes #70

The bug occurs when the player clicks the dialogue box, then the skip button. Because we are not ending the coroutine on skip, the dialogue audio will play indefinitely.